### PR TITLE
CSDK-1749: Add proguard rules to demo app to avoid JNI crash

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,5 @@
+-keep public class co.daily.** {public *;}
+-keep class org.webrtc.** {*;}
+-dontwarn org.webrtc.**
+-keepparameternames
+-keepattributes InnerClasses


### PR DESCRIPTION
These rules should be getting automatically applied through `consumerProguardRules`, this is a workaround while we investigate why that isn't happening.